### PR TITLE
Ensure npm:install be a blocking task.

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1,4 +1,5 @@
 var path = require('path');
+
 /**
  * Create npm object for options
  */

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bluebird": "^2.9.1",
     "chalk": "^0.5.1",
     "path2": "^0.1.0",
-    "shipit-utils": "^1.0.2",
+    "shipit-utils": "^1.1.3",
     "sprintf-js": "^1.0.2",
     "yargs": "^3.4.5"
   }

--- a/tasks/npm/index.js
+++ b/tasks/npm/index.js
@@ -16,7 +16,7 @@ module.exports = function (gruntOrShipit) {
 
   utils.registerTask(gruntOrShipit, 'npm', [
     'npm:install'
-  ]);
+  ], false);
 
   shipit.on('deploy', function () {
 

--- a/tasks/npm/run.js
+++ b/tasks/npm/run.js
@@ -22,7 +22,7 @@ module.exports = function (gruntOrShipit) {
       var cdPath = remote ? shipit.releasePath || shipit.currentPath : shipit.config.workspace;
 
       if(!cdPath) {
-        var msg = remote ? 'Please specify a deploy to path (shipit.config.deployTo)' : 'Please specify a workspace (shipit.config.workspace)'
+        var msg = remote ? 'Please specify a deploy to path (shipit.config.deployTo)' : 'Please specify a workspace (shipit.config.workspace)';
         throw new Error(
           shipit.log(chalk.red(msg))
         );


### PR DESCRIPTION
`shipit-utils.registerTask` defaults to an async task if possible. Here we want to make sure to wait for completion before moving on.
