### PR TITLE
adding path support for node binaries

### DIFF
--- a/tasks/npm/install.js
+++ b/tasks/npm/install.js
@@ -26,12 +26,13 @@ module.exports = function (gruntOrShipit) {
         );
       }
 
+      var nodePath = shipit.config.npm.nodePath || '';
       var args = Array.isArray(shipit.config.npm.installArgs) ? shipit.config.npm.installArgs.join(' ') : shipit.config.npm.installArgs;
       var flags = Array.isArray(shipit.config.npm.installFlags) ? shipit.config.npm.installFlags.join(' ') : shipit.config.npm.installFlags;
       var AF = args ? flags ? args.concat(' ',flags) : args : flags ? flags : '';
 
       return shipit[method](
-        sprintf('node -v && cd %s && npm i %s', cdPath, AF)
+        sprintf('%snode -v && cd %s && %snpm i %s', nodePath, cdPath, nodePath, AF)
       );
 
     }


### PR DESCRIPTION
Ran into an issue where neither node or npm were defined on the remote target, this allows to define a path for both scripts as a workaround 
