### PR TITLE
Support for NPM Private modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Inspired by the [capistrano/composer](https://github.com/capistrano/composer/) e
 - Triggered on the `updated` or `fetched` event from [shipit-deploy](https://github.com/shipitjs/shipit-deploy)
 - Has a direct pass though task to [npm cli](https://docs.npmjs.com/cli)
 - Works via [shipit-cli](https://github.com/shipitjs/shipit) and [grunt-shipit](https://github.com/shipitjs/grunt-shipit)
+- Supports [NPM private modules](https://docs.npmjs.com/private-modules/ci-server-config). 
 
 ## Install
 
@@ -65,6 +66,13 @@ Default: `updated` or `fetched` (depending on `npm.remote` value)
 
 An event name that triggers `npm:install`. Can be set to false to prevent the `npm:install` task from listening to any events.
 
+### `npm.npm_token`
+
+Type: `String`
+Default: ""
+
+The value of npm_token will be set as the NPM_TOKEN environment variable for the npm command. For more details on using 
+npm private modules, refer to the [npm private module documentation](https://docs.npmjs.com/private-modules/ci-server-config)
 
 ### Example `shipitfile.js` options usage
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Inspired by the [capistrano/composer](https://github.com/capistrano/composer/) e
 - Triggered on the `updated` or `fetched` event from [shipit-deploy](https://github.com/shipitjs/shipit-deploy)
 - Has a direct pass though task to [npm cli](https://docs.npmjs.com/cli)
 - Works via [shipit-cli](https://github.com/shipitjs/shipit) and [grunt-shipit](https://github.com/shipitjs/grunt-shipit)
-- Supports [NPM private modules](https://docs.npmjs.com/private-modules/ci-server-config). 
+- Supports [NPM private modules](https://docs.npmjs.com/private-modules/intro). 
 
 ## Install
 

--- a/tasks/npm/init.js
+++ b/tasks/npm/init.js
@@ -17,6 +17,7 @@ module.exports = function (gruntOrShipit) {
     shipit.config.npm.remote = shipit.config.npm.remote !== false;
     shipit.config.npm.installArgs = shipit.config.npm.installArgs || [];
     shipit.config.npm.installFlags = shipit.config.npm.installFlags || [];
+    shipit.config.npm.npm_token = shipit.config.npm.npm_token || '';
 
     var triggerEvent = shipit.config.npm.remote ? 'updated' : 'fetched';
     shipit.config.npm.triggerEvent = shipit.config.npm.triggerEvent !== undefined ? shipit.config.npm.triggerEvent : triggerEvent;

--- a/tasks/npm/install.js
+++ b/tasks/npm/install.js
@@ -29,9 +29,10 @@ module.exports = function (gruntOrShipit) {
       var args = Array.isArray(shipit.config.npm.installArgs) ? shipit.config.npm.installArgs.join(' ') : shipit.config.npm.installArgs;
       var flags = Array.isArray(shipit.config.npm.installFlags) ? shipit.config.npm.installFlags.join(' ') : shipit.config.npm.installFlags;
       var AF = args ? flags ? args.concat(' ',flags) : args : flags ? flags : '';
+      var token = shipit.config.npm.npm_token;
 
       return shipit[method](
-        sprintf('node -v && cd %s && npm i %s', cdPath, AF)
+        sprintf('node -v && cd %s && NPM_TOKEN=%s npm i %s', cdPath, token, AF)
       );
 
     }


### PR DESCRIPTION
Hi,

I Added support for NPM private modules, using the suggested practices defined in the NPM documentation on downloading private modules to deployment and CI servers. 

https://docs.npmjs.com/private-modules/ci-server-config

Thanks,
Matt
