### PR TITLE
Fix #15, add the ability to set a command for npm:cmd in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ Type: `Array` or `String`
 Default: []
 
 An array or string specifying npm flags passed to the [npm install](https://docs.npmjs.com/cli/install) cmd.
+
 ### `npm.cmd`
 
 Type: `String`
 Default: ' '
 
-A string specifying the command to be run by the [npm:cmd](https://github.com/callerc1/shipit-npm#workflow-tasks) (e.g. `'run build'`) **overridden if the `--cmd` argument is set on the command line**.
+A string specifying the command to be run by the [npm:cmd](https://github.com/callerc1/shipit-npm#workflow-tasks) task (e.g. `'run build'`) **overridden if the `--cmd` argument is set on the command line**.
 
 ### `npm.triggerEvent`
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Type: `Array` or `String`
 Default: []
 
 An array or string specifying npm flags passed to the [npm install](https://docs.npmjs.com/cli/install) cmd.
+### `npm.cmd`
+
+Type: `String`
+Default: ' '
+
+A string specifying the command to be run by the [npm:cmd](https://github.com/callerc1/shipit-npm#workflow-tasks) (e.g. `'run build'`) **overridden if the `--cmd` argument is set on the command line**.
 
 ### `npm.triggerEvent`
 

--- a/tasks/npm/cmd.js
+++ b/tasks/npm/cmd.js
@@ -26,12 +26,19 @@ module.exports = function (gruntOrShipit) {
         );
       }
 
+      if (!argv.cmd && shipit.config.npm) {
+        argv.cmd = shipit.config.npm.cmd;
+      }
+
       if(!argv.cmd) {
         throw new Error(
           shipit.log(
             chalk.red('Please specify a npm command eg'),
-            chalk.gray('shipit staging npm:init npm:cmd'),
-            chalk.white('--cmd "update"')
+            chalk.gray('\nshipit staging npm:init npm:cmd'),
+            chalk.white('--cmd "update"'),
+            chalk.red('\nor'),
+            chalk.gray('\n(in your shipitfile)'),
+            chalk.white('npm: { cmd: \'run build\' }')
           )
         );
       }


### PR DESCRIPTION
Explained rather succinctly  by the (also included) entry in the README (under Options):

---
### `npm.cmd`

Type: `String`
Default: ' '

A string specifying the command to be run by the [npm:cmd](https://github.com/callerc1/shipit-npm#workflow-tasks) task (e.g. `'run build'`) **overridden if the `--cmd` argument is set on the command line**.

---

Other changes:
updated error message in npm:cmd to include the config entry as an example.
added .gitignore for node_modules
