### PR TITLE
Add `installCommand` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Default: `true`
 
 A Boolean to determine whether to run the task in local workspace or on the remote.
 
+### `npm.installCommand`
+
+Type: `String`
+Default: `npm install`
+
+A String that specifying install command (e.g. [yarnpkg](https://yarnpkg.com/)).
+
 ### `npm.installArgs`
 
 Type: `Array` or `String`

--- a/tasks/npm/init.js
+++ b/tasks/npm/init.js
@@ -15,6 +15,7 @@ module.exports = function (gruntOrShipit) {
     shipit.currentPath = shipit.config.deployTo ? path.join(shipit.config.deployTo, 'current') : undefined;
     shipit.config.npm = shipit.config.npm || {};
     shipit.config.npm.remote = shipit.config.npm.remote !== false;
+    shipit.config.npm.installCommand = shipit.config.npm.installCommand || 'npm install';
     shipit.config.npm.installArgs = shipit.config.npm.installArgs || [];
     shipit.config.npm.installFlags = shipit.config.npm.installFlags || [];
 

--- a/tasks/npm/install.js
+++ b/tasks/npm/install.js
@@ -31,7 +31,7 @@ module.exports = function (gruntOrShipit) {
       var AF = args ? flags ? args.concat(' ',flags) : args : flags ? flags : '';
 
       return shipit[method](
-        sprintf('node -v && cd %s && npm i %s', cdPath, AF)
+        sprintf('node -v && cd %s && %s %s', cdPath, shipit.config.npm.installCommand, AF)
       );
 
     }


### PR DESCRIPTION
Facebook released yet another package manager called [Yarn](https://yarnpkg.com/). It is very fast and compatible with npm.

I want to use it when deploying my apps, so I added `installCommand` option to replace the command `npm install` to `yarn`.
